### PR TITLE
[IMA-12269] Avoid httpBodyStream read when dealing with multipart requests

### DIFF
--- a/netfox/Core/NFXHelper.swift
+++ b/netfox/Core/NFXHelper.swift
@@ -166,8 +166,16 @@ extension URLRequest {
         }
     }
     
+    func getNFXContentTypeHeader() -> String? {
+        return self.value(forHTTPHeaderField: "Content-Type")
+    }
+    
     func getNFXBody() -> Data {
-        return httpBodyStream?.readfully() ?? URLProtocol.property(forKey: "NFXBodyData", in: self) as? Data ?? Data()
+        if getNFXContentTypeHeader()?.contains("multipart/form-data") == true {
+            return Data()
+        } else {
+            return httpBodyStream?.readfully() ?? URLProtocol.property(forKey: "NFXBodyData", in: self) as? Data ?? Data()
+        }
     }
     
     func getCurl() -> String {


### PR DESCRIPTION
**Change Description**
1. Avoid httpBodyStream read when dealing with multipart requests