### PR TITLE
[IMA-12269] Avoid httpBodyStream read when dealing with multipart requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-<img alt="Version" src="https://img.shields.io/badge/version-1.20.0-green.svg?style=flat-square" />
+<img alt="Version" src="https://img.shields.io/badge/version-1.21.0-green.svg?style=flat-square" />
 <a href="https://travis-ci.org/kasketis/netfox"><img alt="CI Status" src="http://img.shields.io/travis/kasketis/netfox.svg?style=flat-square" /></a>
 <a href="https://cocoapods.org/pods/netfox"><img alt="Cocoapods Compatible" src="https://img.shields.io/cocoapods/v/netfox.svg?style=flat-square" /></a>
 <a href="https://github.com/Carthage/Carthage"><img alt="Carthage Compatible" src="https://img.shields.io/badge/carthage-compatible-4BC51D.svg?style=flat-square" /></a>

--- a/netfox/Core/NFXHelper.swift
+++ b/netfox/Core/NFXHelper.swift
@@ -166,8 +166,16 @@ extension URLRequest {
         }
     }
     
+    func getNFXContentTypeHeader() -> String? {
+        return self.value(forHTTPHeaderField: "Content-Type")
+    }
+    
     func getNFXBody() -> Data {
-        return httpBodyStream?.readfully() ?? URLProtocol.property(forKey: "NFXBodyData", in: self) as? Data ?? Data()
+        if getNFXContentTypeHeader()?.contains("multipart/form-data") == true {
+            return Data()
+        } else {
+            return httpBodyStream?.readfully() ?? URLProtocol.property(forKey: "NFXBodyData", in: self) as? Data ?? Data()
+        }
     }
     
     func getCurl() -> String {


### PR DESCRIPTION
**Change Description**
1. Avoid httpBodyStream read when dealing with multipart requests